### PR TITLE
Refactor: make data provider transparent

### DIFF
--- a/DataProvider.h
+++ b/DataProvider.h
@@ -27,12 +27,12 @@
 class DataConsumer {
 	friend class DataProvider;
 protected:
+	DataProvider *dataProvider = nullptr;
 	virtual void checkPinChange(uint8_t index) = 0;
 };
 
 class DataProvider {
 public:
-	static DataProvider* createDefault() { return DataProvider::createInterruptDataProvider(); };
 	static DataProvider* createInterruptDataProvider();
 	static DataProvider* createPollingDataProvider(uint8_t* input_buffer);
 	

--- a/NewEncoder.cpp
+++ b/NewEncoder.cpp
@@ -50,9 +50,9 @@ const NewEncoder::encoderStateTransition NewEncoder::halfPulseTransitionTable[] 
 };
 
 NewEncoder::NewEncoder(uint8_t aPin, uint8_t bPin, int16_t minValue,
-		int16_t maxValue, int16_t initalValue, uint8_t type, DataProvider *provider) {
+		int16_t maxValue, int16_t initalValue, uint8_t type, uint8_t *pollingBuffer) {
 	active = false;
-	configure(aPin, bPin, minValue, maxValue, initalValue, type, provider);
+	configure(aPin, bPin, minValue, maxValue, initalValue, type, pollingBuffer);
 }
 
 NewEncoder::NewEncoder() {
@@ -78,16 +78,19 @@ void NewEncoder::end() {
 }
 
 void NewEncoder::configure(uint8_t aPin, uint8_t bPin, int16_t minValue,
-		int16_t maxValue, int16_t initalValue, uint8_t type, DataProvider *provider) {
+		int16_t maxValue, int16_t initalValue, uint8_t type, uint8_t *pollingBuffer) {
 
 	if (active) {
 		end();
 	}
-
-	this->dataProvider = provider;
-	if (provider == nullptr) {
-		this->dataProvider = DataProvider::createDefault();
+	
+	delete dataProvider;
+	if (pollingBuffer == nullptr) {
+		dataProvider = DataProvider::createInterruptDataProvider();
+	} else {
+		dataProvider = DataProvider::createPollingDataProvider(pollingBuffer);
 	}
+
 	dataProvider->configure(aPin, bPin, this);
 
 	_minValue = minValue;

--- a/NewEncoder.h
+++ b/NewEncoder.h
@@ -35,11 +35,11 @@ private:
 	using encoderStateTransition = uint8_t[4];
 
 public:
-	NewEncoder(uint8_t aPin, uint8_t bPin, int16_t minValue, int16_t maxValue, int16_t initalValue, uint8_t type = FULL_PULSE, DataProvider *provider = nullptr);
+	NewEncoder(uint8_t aPin, uint8_t bPin, int16_t minValue, int16_t maxValue, int16_t initalValue, uint8_t type = FULL_PULSE, uint8_t *pollingBuffer = nullptr);
 	NewEncoder();
 	virtual ~NewEncoder();
 	virtual bool begin();
-	virtual void configure(uint8_t aPin, uint8_t bPin, int16_t minValue, int16_t maxValue, int16_t initalValue, uint8_t type = FULL_PULSE,  DataProvider *provider = nullptr);
+	virtual void configure(uint8_t aPin, uint8_t bPin, int16_t minValue, int16_t maxValue, int16_t initalValue, uint8_t type = FULL_PULSE,  uint8_t *pollingBuffer = nullptr);
 	virtual void end();
 	bool enabled() const;
 	void attachCallback(EncoderCallBack cback, void *uPtr = nullptr);
@@ -49,6 +49,8 @@ public:
 
 	NewEncoder(const NewEncoder&) = delete; // delete copy constructor. no copying allowed
 	NewEncoder& operator=(const NewEncoder&) = delete; // delete operator=(). no assignment allowed
+
+	void pollInput() { dataProvider->inputUpdate(); };
 
 protected:
 	// This function may be implemented in an inherited class to customize the increment/decrement and min/max behavior.
@@ -65,7 +67,6 @@ protected:
 private:
 	void pinChangeHandler(uint8_t index);
 	bool active = false;
-	DataProvider *dataProvider = nullptr;
 
 	const encoderStateTransition *tablePtr = nullptr;
 	volatile uint8_t currentStateVariable;

--- a/POLLING.md
+++ b/POLLING.md
@@ -1,6 +1,6 @@
 
 # About polling mode
-Initially, the NewEncoder instance uses only interrupts to handle the data input from encoder pins.
+Initially, the NewEncoder library uses only interrupts to handle the data input from encoder pins.
 However, on some board, only a few pins support interrupt.
 The polling mode allows the encoder to work with a input buffer, therefore we can hook more encoders.
 
@@ -9,29 +9,28 @@ Here we have two kinds of data provider for woking in interrupt mode and polling
 -  `InterruptDataProvider`
 -  `PollingDataProvider`
 
-The constructor of `NewEncoder` accepts a data provider instance as its last parameter.  If it is `nullptr`, the `InterruptDataProvider` is used by default.
+The constructor of `NewEncoder` accepts the pointer to a input buffer as its last parameter.  If it is `nullptr`, the `InterruptDataProvider` is used by default. Otherwise, the `PollingDataProvider` is used internally.
 ```
-NewEncoder(uint8_t  aPin, uint8_t  bPin, int16_t  minValue, int16_t maxValue, int16_t initalValue, uint8_t  type = FULL_PULSE, DataProvider *provider = nullptr);
+NewEncoder(uint8_t  aPin, uint8_t  bPin, int16_t  minValue, int16_t maxValue, int16_t initalValue, uint8_t  type = FULL_PULSE, uint8_t *inputBuffer = nullptr);
 ```
-To initialize the encoder instance with data provider explicitly specified, here's how
+here's the examples.
 ```
-// To create an encoder with interrupt data provider
-DataProvider *provider = DataProvider::createInterruptDataProvider();
-NewEncoder encoder1(2, 3, -20, 20, 0, FULL_PULSE, provider);
+// To create an encoder with interrupt data provider, the following 4 lines work identically.
+NewEncoder encoder(2, 3, -20, 20, 0);
+NewEncoder encoder(2, 3, -20, 20, 0, FULL_PULSE);
+NewEncoder encoder(2, 3, -20, 20, 0, FULL_PULSE, NULL);
+NewEncoder encoder(2, 3, -20, 20, 0, FULL_PULSE, nullptr);
 
 // To create an encoder with interrupt data provider
 volatile uint32_t buffer = 0xFF; // the buffer can be any size, and usually the initial value for all bits should be "pulled up" to 1.
-DataProvider *pollingProvider = DataProvider::createPollingDataProvider((uint8_t *)buffer);
-NewEncoder encoder2(2, 3, -20, 20, 0, FULL_PULSE, pollingProvider);
+NewEncoder encoder2(2, 3, -20, 20, 0, FULL_PULSE, (uint8_t *)buffer);
 ```
-**NOTES:**
-The ownership of data provider is not transfered to the encoder instance, if needed, you have to `delete` them manually.
 
 ## Update encoder in polling mode
-With pulling mode, we need to call `DataProvider::inputUpdate()` to notify its encoder to check the latest state.
+With pulling mode, we need to call `DataProvider::pollInput()` to notify its encoder to check the latest state.
 ```
 buffer = getLatestValue();
-pollingProvider->inputUpdate();
+pollingProvider->pollInput();
 ```
 
 For details, please check the sample sketch located at `examples/Polling/PollingSingleEncoder.ino`.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # NewEncoder
-Interrupt-driven rotary encoder library. Works both with encoders that produce one complete quadrature cycle every detent (such as [this Bourns unit sold by Adafruit](https://www.adafruit.com/product/377)) and those that produce one complete quadrature cycle for every two detents (such as [this Alps unit sold by Mouser](https://www.mouser.com/ProductDetail/alps/ec11e15244g1/?qs=YMSFtX0bdJDiV4LBO61anw==&countrycode=US&currencycode=USD)).
+Rotary encoder library. Works both with encoders that produce one complete quadrature cycle every detent (such as [this Bourns unit sold by Adafruit](https://www.adafruit.com/product/377)) and those that produce one complete quadrature cycle for every two detents (such as [this Alps unit sold by Mouser](https://www.mouser.com/ProductDetail/alps/ec11e15244g1/?qs=YMSFtX0bdJDiV4LBO61anw==&countrycode=US&currencycode=USD)).
 
 The encoders' switches are debounced using a state table approach.
 
-Two interrupt-capable pins are required for each encoder connected. Thus, only one encoder can be used with an Arduino Uno for example.
+The encoder can work either in interrupt-driven mode or polling mode.
+For the interrupt-driven mode, TWO interrupt-capable pins are required for each encoder connected. Thus, only one encoder can be used with an Arduino Uno for example.
 
 The encoders' "A" and "B" terminals should be connected to the processor's inputs and its common terminal should be grounded. The library enables the processor's internal pull-ups, so external ones are not required.
 # Version 2.x:
@@ -41,7 +42,7 @@ This provides interfacing to the encoder, interrupt handling, and rotation count
 ## Public NewEncoder Members Functions:
 ### Constructor - creates  and configures object
 
-    NewEncoder(uint8_t aPin, uint8_t bPin, int16_t minValue, int16_t maxValue, int16_t initalValue, uint8_t type = FULL_PULSE, DataProvider *provider = nullptr)
+    NewEncoder(uint8_t aPin, uint8_t bPin, int16_t minValue, int16_t maxValue, int16_t initalValue, uint8_t type = FULL_PULSE, uint8_t *inputBuffer = nullptr)
 **Arguments:**
  - **uint8_t aPin** - Hardware pin connected to the encoder's "A" terminal.
  - **uint8_t bPin** - Hardware pin connected to the encoder's "B" terminal.
@@ -49,7 +50,7 @@ This provides interfacing to the encoder, interrupt handling, and rotation count
  - **int16_t maxValue** - Highest count value to be returned. Further clockwise rotation produces no further change in output.
  - **int16_t initalValue** - Initial encoder value. Should be between minValue and maxValue
  - **uint8_t type** Type of encoder - FULL_PULSE (default, one quadrature pulse per detent) or HALF_PULSE (one quadrature pulse for every two detents)
- - **DataProvider \*provider** - Either `InterruptDataProvider` or `PollingDataProvider`, the data provider does the underlying jobs to handle the input changes on each pin. **Please check the [`POLLING.md`](POLLING.md) for more details**.
+ - **uint8_t \*inputBuffer** - The pointer to input buffer for polling mode. If it is NULL or nullptr, the encoder will work in interrupt-driven mode. **Please check the [`POLLING.md`](POLLING.md) for more details**.
  
 ### Constructor - only creates object
 
@@ -58,7 +59,7 @@ This provides interfacing to the encoder, interrupt handling, and rotation count
 
 ### Configure or Re-configure an encoder object
 
-    void configure(uint8_t aPin, uint8_t bPin, int16_t minValue, int16_t maxValue, int16_t initalValue, uint8_t type = FULL_PULSE);
+    void configure(uint8_t aPin, uint8_t bPin, int16_t minValue, int16_t maxValue, int16_t initalValue, uint8_t type = FULL_PULSE, uint8_t *inputBuffer = nullptr);
 **Arguments:** Same as Constructor
 **Returns:**    Nothing
 
@@ -74,6 +75,13 @@ This provides interfacing to the encoder, interrupt handling, and rotation count
 ### Disable an encoder object
 
      void end();
+  **Arguments:** None
+   
+  **Returns:**    Nothing
+
+### Poll the pin values from the input buffer
+
+     void pollInput();
   **Arguments:** None
    
   **Returns:**    Nothing

--- a/examples/Polling/PollingSingleEncoder.ino
+++ b/examples/Polling/PollingSingleEncoder.ino
@@ -10,8 +10,7 @@
 #define PIN_B 5
 
 volatile int16_t pollingBuffer = 0xFF;
-DataProvider *pollingDataProvider = DataProvider::createPollingDataProvider((uint8_t *)&pollingBuffer);
-NewEncoder encoder(PIN_A, PIN_B, -20, 20, 0, FULL_PULSE, pollingDataProvider);
+NewEncoder encoder(PIN_A, PIN_B, -20, 20, 0, FULL_PULSE, (uint8_t *)pollingBuffer);
 int16_t prevEncoderValue;
 
 void setup() {
@@ -48,7 +47,7 @@ void updatePollingBuffer() {
   pollingBuffer = (pollingBuffer & ~(0b1 << PIN_B)) | (valueB << PIN_B);
 
   // read data from the input buffer, and update its linked encoder.
-  pollingDataProvider->inputUpdate();
+  encoder.pollInput();
 }
 
 void loop() {


### PR DESCRIPTION
- [x] Manage the lifecycle of data provider inside `NewEncoder`